### PR TITLE
Move `check-manifest` to CI as it's too slow

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -29,3 +29,6 @@ jobs:
         uses: sourcery-ai/action@v1
         with:
           token: ${{ secrets.SOURCERY_TOKEN }}
+
+      - name: check-manifest
+        uses: tj-actions/check-manifest@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,9 +35,3 @@ repos:
     rev: 23.1.0
     hooks:
       - id: black
-  - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.49"
-    hooks:
-      - id: check-manifest
-        args: [--no-build-isolation]
-        additional_dependencies: [setuptools-scm]


### PR DESCRIPTION
Fixes #50 