### PR TITLE
Limit examples to only run once per branch

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -6,6 +6,12 @@ on:
       - main
   pull_request:
 
+concurrency:
+  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-
+    ${{ github.event.pull_request.number || github.ref }}
+
 jobs:
   codeblocks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Should reduce email count and reduce confusion when something is broken