### PR TITLE
Fix parallel builds in `coveralls`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           - "3.10"
           - "3.11"
     steps:
-      - uses: paddyroddy/.github/actions/python/tox@2875a6d0e8cde7569a844579e5528338cffae08f # v0
+      - uses: paddyroddy/.github/actions/python/tox@d847296ec70e63ba26408f9b354de8a40ce2f006 # v0
         with:
           cache-path: |-
             .tox
@@ -29,3 +29,23 @@ jobs:
           operating-system: ${{ matrix.os }}
           pyproject-toml: ./pyproject.toml
           python-version: ${{ matrix.python-version }}
+
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@v2
+        with:
+          flag-name: run-${{ matrix.os }}-${{ matrix.python-version }}
+          parallel: true
+
+  finish:
+    needs: test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true
+          carryforward: "run-macos-latest-3.10,\
+            run-ubuntu-latest-3.10,\
+            run-macos-latest-3.11,\
+            run-ubuntu-latest-3.11"


### PR DESCRIPTION
Causing recent failures. Have taken `coveralls` out of the composite action due to the need of the separate job required and the `carryforward` argument.