### PR TITLE
Avoid downloading data on initial import

### DIFF
--- a/src/sleplet/functions/axisymmetric_wavelet_coefficients_africa.py
+++ b/src/sleplet/functions/axisymmetric_wavelet_coefficients_africa.py
@@ -29,8 +29,8 @@ class AxisymmetricWaveletCoefficientsAfrica(Flm):
     j: int | None = None
     """Option to select a given wavelet. `None` indicates the scaling function,
     whereas `0` would correspond to the selected `j_min`."""
-    _africa: Africa = pydantic.Field(
-        default=Africa(1),
+    _africa: Africa | None = pydantic.Field(
+        default=None,
         init_var=False,
         repr=False,
     )

--- a/src/sleplet/functions/axisymmetric_wavelet_coefficients_earth.py
+++ b/src/sleplet/functions/axisymmetric_wavelet_coefficients_earth.py
@@ -29,8 +29,8 @@ class AxisymmetricWaveletCoefficientsEarth(Flm):
     j: int | None = None
     """Option to select a given wavelet. `None` indicates the scaling function,
     whereas `0` would correspond to the selected `j_min`."""
-    _earth: Earth = pydantic.Field(
-        default=Earth(0),
+    _earth: Earth | None = pydantic.Field(
+        default=None,
         init_var=False,
         repr=False,
     )

--- a/src/sleplet/functions/axisymmetric_wavelet_coefficients_south_america.py
+++ b/src/sleplet/functions/axisymmetric_wavelet_coefficients_south_america.py
@@ -28,8 +28,8 @@ class AxisymmetricWaveletCoefficientsSouthAmerica(Flm):
     j: int | None = None
     """Option to select a given wavelet. `None` indicates the scaling function,
     whereas `0` would correspond to the selected `j_min`."""
-    _south_america: SouthAmerica = pydantic.Field(
-        default=SouthAmerica(1),
+    _south_america: SouthAmerica | None = pydantic.Field(
+        default=None,
         init_var=False,
         repr=False,
     )

--- a/src/sleplet/functions/fp.py
+++ b/src/sleplet/functions/fp.py
@@ -20,8 +20,8 @@ from sleplet.functions.coefficients import Coefficients
 class Fp(Coefficients):
     """Abstract parent class to handle Slepian coefficients on the sphere."""
 
-    slepian: sleplet.slepian.slepian_functions.SlepianFunctions = pydantic.Field(
-        default=sleplet.slepian.slepian_polar_cap.SlepianPolarCap(0, theta_max=1),
+    slepian: sleplet.slepian.slepian_functions.SlepianFunctions | None = pydantic.Field(
+        default=None,
         init_var=False,
         repr=False,
     )

--- a/src/sleplet/meshes/mesh.py
+++ b/src/sleplet/meshes/mesh.py
@@ -26,7 +26,7 @@ class Mesh:
     zoom: bool = False
     """Whether to zoom in on the pre-selected region of the mesh in the
     plots."""
-    _camera_view: go.layout.scene.Camera = pydantic.Field(
+    _camera_view: go.layout.scene.Camera | None = pydantic.Field(
         default=go.layout.scene.Camera(),
         init_var=False,
         repr=False,

--- a/src/sleplet/meshes/mesh_slepian_coefficients.py
+++ b/src/sleplet/meshes/mesh_slepian_coefficients.py
@@ -8,7 +8,6 @@ import typing_extensions
 
 import sleplet._validation
 import sleplet.noise
-from sleplet.meshes.mesh import Mesh
 from sleplet.meshes.mesh_coefficients import MeshCoefficients
 from sleplet.meshes.mesh_slepian import MeshSlepian
 
@@ -17,8 +16,8 @@ from sleplet.meshes.mesh_slepian import MeshSlepian
 class MeshSlepianCoefficients(MeshCoefficients):
     """Abstract parent class to handle Slepian coefficients on the mesh."""
 
-    mesh_slepian: MeshSlepian = pydantic.Field(
-        default=MeshSlepian(Mesh("bird")),
+    mesh_slepian: MeshSlepian | None = pydantic.Field(
+        default=None,
         init_var=False,
         repr=False,
     )


### PR DESCRIPTION
As identified here https://github.com/pyOpenSci/software-submission/issues/149#issuecomment-1825991957, upon the initial import `sleplet` was downloading various files. These were all due to `pydantic.Field(default`. In this, I change them all to `None`