### PR TITLE
Use `tox-gh` under the hood over `tox-gh-actions`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,12 +23,11 @@ jobs:
           - "3.12"
     steps:
       # yamllint disable-line rule:line-length
-      - uses: paddyroddy/.github/actions/python/tox@cae02393710f18f5fbacd9545d1a38f0d661758e # v0
+      - uses: paddyroddy/.github/actions/python/tox@2e83ccde571114eea4dacae50214fd1dff839be0 # v0
         with:
           cache-path: |-
             .tox
             ~/.cache/sleplet
-          operating-system: ${{ matrix.os }}
           pyproject-toml: ./pyproject.toml
           python-version: ${{ matrix.python-version }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,5 +220,5 @@ legacy_tox_ini = """
         pytest-cov
 
     [tox]
-    env_list = py{310,311,312}
+    env_list = py{311,312}
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,15 +208,10 @@ overrides."tool.ruff.lint.isort.section-order".inline_arrays = false
 
 [tool.tox]
 legacy_tox_ini = """
-    [gh-actions]
+    [gh]
     python =
         3.11: py311
         3.12: py312
-
-    [gh-actions:env]
-    OS =
-        ubuntu-latest: linux
-        macos-latest: macos
 
     [testenv]
     commands =
@@ -225,5 +220,5 @@ legacy_tox_ini = """
         pytest-cov
 
     [tox]
-    env_list = py{310,311,312}-{linux,macos}
+    env_list = py{310,311,312}
 """


### PR DESCRIPTION
Part of the `tox-dev` organisation. Working towards #419.