### PR TITLE
Remove string conversion following IGL upgrade

### DIFF
--- a/src/sleplet/_mesh_methods.py
+++ b/src/sleplet/_mesh_methods.py
@@ -114,7 +114,7 @@ def read_mesh(
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.int_]]:
     """Read in the given mesh."""
     vertices, faces = igl.read_triangle_mesh(
-        str(_data_path / f"meshes_polygons_{mesh_config['FILENAME']}"),
+        _data_path / f"meshes_polygons_{mesh_config['FILENAME']}",
     )
     return igl.upsample(vertices, faces, number_of_subdivs=mesh_config["UPSAMPLE"])
 


### PR DESCRIPTION
Following the merge of https://github.com/libigl/libigl-python-bindings/pull/243 this should no longer be required (see https://github.com/libigl/libigl-python-bindings/issues/82#event-16153046532).