### PR TITLE
No longer use deploy composite action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,8 +16,33 @@ jobs:
     permissions:
       id-token: write
     steps:
-      # yamllint disable-line rule:line-length
-      - uses: paddyroddy/.github/actions/python/deployment@e267230bc5b4dd8170b46bcf864d6de7cf123d33 # v0
+      - name: Checkout source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5
         with:
-          pyproject-toml: ./pyproject.toml
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        shell: bash
+        run: python -m pip install build
+
+      - name: Build distributions
+        shell: bash
+        run: python -m build
+
+      - name: Publish package to TestPyPI
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          verbose: true
+
+      - name: Publish package to PyPI
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true


### PR DESCRIPTION
https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#non-goals is now broken