### PR TITLE
Split up deployment job

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,10 +11,8 @@ on:
   pull_request:
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     steps:
       - name: Checkout source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -34,15 +32,45 @@ jobs:
         shell: bash
         run: python -m build
 
+      - name: Upload distribution
+        # yamllint disable-line rule:line-length
+        uses: hynek/build-and-inspect-python-package@b5076c307dc91924a82ad150cdd1533b444d3310 # v2
+
+  deploy-test-pypi:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download distributions
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
+        with:
+          name: Packages
+          path: dist
+
       - name: Publish package to TestPyPI
-        if: startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
           verbose: true
 
+  deploy-pypi:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download distributions
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
+        with:
+          name: Packages
+          path: dist
+
       - name: Publish package to PyPI
-        if: startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true


### PR DESCRIPTION
One can no longer deploy to PyPI and TestPyPI in the same job https://github.com/pypa/gh-action-pypi-publish/issues/339 https://github.com/pypa/gh-action-pypi-publish/issues/352. Also, introducing https://github.com/hynek/build-and-inspect-python-package to tidy up steps.