### PR TITLE
Prepare for lazy imports with `__lazy_modules__`

### DIFF
--- a/src/sleplet/_array_methods.py
+++ b/src/sleplet/_array_methods.py
@@ -1,3 +1,7 @@
+__lazy_modules__ = [
+    "numpy",
+]
+
 import typing
 
 import numpy as np

--- a/src/sleplet/_convolution_methods.py
+++ b/src/sleplet/_convolution_methods.py
@@ -1,3 +1,7 @@
+__lazy_modules__ = [
+    "numpy",
+]
+
 import typing
 
 import numpy as np

--- a/src/sleplet/_data/create_earth_flm.py
+++ b/src/sleplet/_data/create_earth_flm.py
@@ -1,3 +1,9 @@
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+    "scipy",
+]
+
 import numpy as np
 import numpy.typing as npt
 import scipy.io as sio

--- a/src/sleplet/_data/create_wmap_flm.py
+++ b/src/sleplet/_data/create_wmap_flm.py
@@ -1,3 +1,9 @@
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+    "scipy",
+]
+
 import numpy as np
 import numpy.typing as npt
 import scipy.io as sio

--- a/src/sleplet/_data/setup_pooch.py
+++ b/src/sleplet/_data/setup_pooch.py
@@ -1,3 +1,8 @@
+__lazy_modules__ = [
+    "platformdirs",
+    "pooch",
+]
+
 import logging
 import os
 import typing

--- a/src/sleplet/_integration_methods.py
+++ b/src/sleplet/_integration_methods.py
@@ -1,3 +1,8 @@
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+]
+
 import functools
 import typing
 

--- a/src/sleplet/_mask_methods.py
+++ b/src/sleplet/_mask_methods.py
@@ -1,3 +1,9 @@
+__lazy_modules__ = [
+    "numpy",
+    "platformdirs",
+    "pyssht",
+]
+
 import logging
 import os
 import pathlib

--- a/src/sleplet/_mesh_methods.py
+++ b/src/sleplet/_mesh_methods.py
@@ -1,3 +1,11 @@
+__lazy_modules__ = [
+    "igl",
+    "numpy",
+    "platformdirs",
+    "scipy",
+    "tomli",
+]
+
 import logging
 import pathlib
 import typing

--- a/src/sleplet/_parallel_methods.py
+++ b/src/sleplet/_parallel_methods.py
@@ -1,3 +1,8 @@
+__lazy_modules__ = [
+    "multiprocess",
+    "numpy",
+]
+
 import multiprocess.shared_memory
 import numpy as np
 import numpy.typing as npt

--- a/src/sleplet/_plotly_methods.py
+++ b/src/sleplet/_plotly_methods.py
@@ -1,3 +1,7 @@
+__lazy_modules__ = [
+    "plotly",
+]
+
 import typing
 
 import plotly.graph_objects as go

--- a/src/sleplet/_scripts/plotting_on_sphere.py
+++ b/src/sleplet/_scripts/plotting_on_sphere.py
@@ -1,3 +1,8 @@
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+]
+
 import argparse
 import logging
 

--- a/src/sleplet/_slepian_arbitrary_methods.py
+++ b/src/sleplet/_slepian_arbitrary_methods.py
@@ -1,3 +1,7 @@
+__lazy_modules__ = [
+    "numpy",
+]
+
 import typing
 
 import numpy as np

--- a/src/sleplet/_smoothing.py
+++ b/src/sleplet/_smoothing.py
@@ -1,3 +1,8 @@
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/_string_methods.py
+++ b/src/sleplet/_string_methods.py
@@ -1,3 +1,7 @@
+__lazy_modules__ = [
+    "numpy",
+]
+
 import fractions
 import re
 import typing

--- a/src/sleplet/functions/africa.py
+++ b/src/sleplet/functions/africa.py
@@ -1,5 +1,11 @@
 """Contains the `Africa` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/functions/axisymmetric_wavelet_coefficients_africa.py
+++ b/src/sleplet/functions/axisymmetric_wavelet_coefficients_africa.py
@@ -1,5 +1,11 @@
 """Contains the `AxisymmetricWaveletCoefficientsAfrica` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pys2let",
+    "typing_extensions",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/functions/axisymmetric_wavelet_coefficients_earth.py
+++ b/src/sleplet/functions/axisymmetric_wavelet_coefficients_earth.py
@@ -1,5 +1,11 @@
 """Contains the `AxisymmetricWaveletCoefficientsEarth` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pys2let",
+    "typing_extensions",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/functions/axisymmetric_wavelet_coefficients_south_america.py
+++ b/src/sleplet/functions/axisymmetric_wavelet_coefficients_south_america.py
@@ -1,5 +1,11 @@
 """Contains the `AxisymmetricWaveletCoefficientsSouthAmerica` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pys2let",
+    "typing_extensions",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/functions/axisymmetric_wavelets.py
+++ b/src/sleplet/functions/axisymmetric_wavelets.py
@@ -1,5 +1,11 @@
 """Contains the `AxisymmetricWavelets` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pys2let",
+    "typing_extensions",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/functions/coefficients.py
+++ b/src/sleplet/functions/coefficients.py
@@ -1,5 +1,10 @@
 """Contains the abstract `Coefficients` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import abc
 import dataclasses
 

--- a/src/sleplet/functions/dirac_delta.py
+++ b/src/sleplet/functions/dirac_delta.py
@@ -1,5 +1,11 @@
 """Contains the `DiracDelta` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/functions/earth.py
+++ b/src/sleplet/functions/earth.py
@@ -1,5 +1,10 @@
 """Contains the `Earth` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/functions/elongated_gaussian.py
+++ b/src/sleplet/functions/elongated_gaussian.py
@@ -1,5 +1,10 @@
 """Contains the `ElongatedGaussian` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/functions/flm.py
+++ b/src/sleplet/functions/flm.py
@@ -1,5 +1,11 @@
 """Contains the abstract `Flm` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+    "typing_extensions",
+]
+
 import abc
 
 import numpy as np

--- a/src/sleplet/functions/fp.py
+++ b/src/sleplet/functions/fp.py
@@ -1,5 +1,10 @@
 """Contains the abstract `Fp` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import abc
 
 import numpy as np

--- a/src/sleplet/functions/gaussian.py
+++ b/src/sleplet/functions/gaussian.py
@@ -1,5 +1,11 @@
 """Contains the `Gaussian` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/functions/harmonic_gaussian.py
+++ b/src/sleplet/functions/harmonic_gaussian.py
@@ -1,5 +1,11 @@
 """Contains the `HarmonicGaussian` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/functions/identity.py
+++ b/src/sleplet/functions/identity.py
@@ -1,5 +1,10 @@
 """Contains the `Identity` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/functions/noise_earth.py
+++ b/src/sleplet/functions/noise_earth.py
@@ -1,5 +1,10 @@
 """Contains the `NoiseEarth` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/functions/ridgelets.py
+++ b/src/sleplet/functions/ridgelets.py
@@ -1,5 +1,13 @@
 """Contains the `Ridgelets` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pys2let",
+    "pyssht",
+    "scipy",
+    "typing_extensions",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/functions/slepian.py
+++ b/src/sleplet/functions/slepian.py
@@ -1,5 +1,10 @@
 """Contains the `Slepian` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/functions/slepian_africa.py
+++ b/src/sleplet/functions/slepian_africa.py
@@ -1,5 +1,10 @@
 """Contains the `SlepianAfrica` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/functions/slepian_dirac_delta.py
+++ b/src/sleplet/functions/slepian_dirac_delta.py
@@ -1,5 +1,11 @@
 """Contains the `SlepianDiracDelta` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+    "typing_extensions",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/functions/slepian_identity.py
+++ b/src/sleplet/functions/slepian_identity.py
@@ -1,5 +1,10 @@
 """Contains the `SlepianIdentity` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/functions/slepian_noise_africa.py
+++ b/src/sleplet/functions/slepian_noise_africa.py
@@ -1,5 +1,10 @@
 """Contains the `SlepianNoiseAfrica` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/functions/slepian_noise_south_america.py
+++ b/src/sleplet/functions/slepian_noise_south_america.py
@@ -1,5 +1,10 @@
 """Contains the `SlepianNoiseSouthAmerica` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/functions/slepian_south_america.py
+++ b/src/sleplet/functions/slepian_south_america.py
@@ -1,5 +1,10 @@
 """Contains the `SlepianSouthAmerica` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/functions/slepian_wavelet_coefficients_africa.py
+++ b/src/sleplet/functions/slepian_wavelet_coefficients_africa.py
@@ -1,5 +1,11 @@
 """Contains the `SlepianWaveletCoefficientsAfrica` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pys2let",
+    "typing_extensions",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/functions/slepian_wavelet_coefficients_south_america.py
+++ b/src/sleplet/functions/slepian_wavelet_coefficients_south_america.py
@@ -1,5 +1,11 @@
 """Contains the `SlepianWaveletCoefficientsSouthAmerica` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pys2let",
+    "typing_extensions",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/functions/slepian_wavelets.py
+++ b/src/sleplet/functions/slepian_wavelets.py
@@ -1,5 +1,11 @@
 """Contains the `SlepianWavelets` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pys2let",
+    "typing_extensions",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/functions/south_america.py
+++ b/src/sleplet/functions/south_america.py
@@ -1,5 +1,11 @@
 """Contains the `SouthAmerica` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/functions/spherical_harmonic.py
+++ b/src/sleplet/functions/spherical_harmonic.py
@@ -1,5 +1,11 @@
 """Contains the `SphericalHarmonic` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/functions/squashed_gaussian.py
+++ b/src/sleplet/functions/squashed_gaussian.py
@@ -1,5 +1,10 @@
 """Contains the `SquashedGaussian` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/functions/wmap.py
+++ b/src/sleplet/functions/wmap.py
@@ -1,5 +1,10 @@
 """Contains the `Wmap` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/harmonic_methods.py
+++ b/src/sleplet/harmonic_methods.py
@@ -1,5 +1,10 @@
 """Methods to perform operations in Fourier space of the sphere or mesh."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+]
+
 import collections
 import typing
 

--- a/src/sleplet/meshes/_mesh_slepian_decomposition.py
+++ b/src/sleplet/meshes/_mesh_slepian_decomposition.py
@@ -1,3 +1,8 @@
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import dataclasses
 import logging
 

--- a/src/sleplet/meshes/mesh.py
+++ b/src/sleplet/meshes/mesh.py
@@ -1,5 +1,11 @@
 """Contains the `Mesh` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "plotly",
+    "typing_extensions",
+]
+
 import dataclasses
 import typing
 

--- a/src/sleplet/meshes/mesh_basis_functions.py
+++ b/src/sleplet/meshes/mesh_basis_functions.py
@@ -1,5 +1,10 @@
 """Contains the `MeshBasisFunctions` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/meshes/mesh_coefficients.py
+++ b/src/sleplet/meshes/mesh_coefficients.py
@@ -1,5 +1,10 @@
 """Contains the abstract `MeshCoefficients` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import abc
 import dataclasses
 

--- a/src/sleplet/meshes/mesh_field.py
+++ b/src/sleplet/meshes/mesh_field.py
@@ -1,5 +1,11 @@
 """Contains the `MeshField` class."""
 
+__lazy_modules__ = [
+    "igl",
+    "numpy",
+    "typing_extensions",
+]
+
 import igl
 import numpy as np
 import numpy.typing as npt

--- a/src/sleplet/meshes/mesh_harmonic_coefficients.py
+++ b/src/sleplet/meshes/mesh_harmonic_coefficients.py
@@ -1,5 +1,11 @@
 """Contains the abstract `MeshHarmonicCoefficients` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing",
+    "typing_extensions",
+]
+
 import abc
 import typing
 

--- a/src/sleplet/meshes/mesh_noise_field.py
+++ b/src/sleplet/meshes/mesh_noise_field.py
@@ -1,5 +1,10 @@
 """Contains the `MeshNoiseField` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/meshes/mesh_slepian.py
+++ b/src/sleplet/meshes/mesh_slepian.py
@@ -1,5 +1,11 @@
 """Contains the `MeshSlepian` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "platformdirs",
+    "typing_extensions",
+]
+
 import concurrent.futures
 import logging
 import os

--- a/src/sleplet/meshes/mesh_slepian_coefficients.py
+++ b/src/sleplet/meshes/mesh_slepian_coefficients.py
@@ -1,5 +1,10 @@
 """Contains the abstract `MeshSlepianCoefficients` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import abc
 import typing
 

--- a/src/sleplet/meshes/mesh_slepian_field.py
+++ b/src/sleplet/meshes/mesh_slepian_field.py
@@ -1,5 +1,10 @@
 """Contains the `MeshSlepianField` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/meshes/mesh_slepian_functions.py
+++ b/src/sleplet/meshes/mesh_slepian_functions.py
@@ -1,5 +1,10 @@
 """Contains the `MeshSlepianFunctions` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/meshes/mesh_slepian_noise_field.py
+++ b/src/sleplet/meshes/mesh_slepian_noise_field.py
@@ -1,5 +1,10 @@
 """Contains the `MeshSlepianNoiseField` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import numpy as np
 import numpy.typing as npt
 import pydantic

--- a/src/sleplet/meshes/mesh_slepian_wavelet_coefficients.py
+++ b/src/sleplet/meshes/mesh_slepian_wavelet_coefficients.py
@@ -1,5 +1,11 @@
 """Contains the `MeshSlepianWaveletCoefficients` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pys2let",
+    "typing_extensions",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/meshes/mesh_slepian_wavelets.py
+++ b/src/sleplet/meshes/mesh_slepian_wavelets.py
@@ -1,5 +1,11 @@
 """Contains the `MeshSlepianWavelets` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pys2let",
+    "typing_extensions",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/noise.py
+++ b/src/sleplet/noise.py
@@ -1,5 +1,10 @@
 """Methods to handle noise in Fourier or wavelet space."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/plot_methods.py
+++ b/src/sleplet/plot_methods.py
@@ -1,5 +1,10 @@
 """Methods to help in creating plots."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/plotting/_create_plot_mesh.py
+++ b/src/sleplet/plotting/_create_plot_mesh.py
@@ -1,3 +1,9 @@
+__lazy_modules__ = [
+    "numpy",
+    "plotly",
+    "typing_extensions",
+]
+
 import dataclasses
 import logging
 

--- a/src/sleplet/plotting/_create_plot_sphere.py
+++ b/src/sleplet/plotting/_create_plot_sphere.py
@@ -1,3 +1,10 @@
+__lazy_modules__ = [
+    "numpy",
+    "plotly",
+    "pyssht",
+    "typing_extensions",
+]
+
 import dataclasses
 import logging
 

--- a/src/sleplet/slepian/_slepian_decomposition.py
+++ b/src/sleplet/slepian/_slepian_decomposition.py
@@ -1,3 +1,9 @@
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+    "typing_extensions",
+]
+
 import dataclasses
 import logging
 

--- a/src/sleplet/slepian/region.py
+++ b/src/sleplet/slepian/region.py
@@ -1,5 +1,9 @@
 """Contains the `Region` class."""
 
+__lazy_modules__ = [
+    "typing_extensions",
+]
+
 import logging
 
 import pydantic

--- a/src/sleplet/slepian/slepian_arbitrary.py
+++ b/src/sleplet/slepian/slepian_arbitrary.py
@@ -1,5 +1,12 @@
 """Contains the `SlepianArbitrary` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "platformdirs",
+    "pyssht",
+    "typing_extensions",
+]
+
 import concurrent.futures
 import logging
 import os

--- a/src/sleplet/slepian/slepian_functions.py
+++ b/src/sleplet/slepian/slepian_functions.py
@@ -1,5 +1,10 @@
 """Contains the abstract `SlepianFunctions` class."""
 
+__lazy_modules__ = [
+    "numpy",
+    "typing_extensions",
+]
+
 import abc
 import dataclasses
 import logging

--- a/src/sleplet/slepian/slepian_limit_lat_lon.py
+++ b/src/sleplet/slepian/slepian_limit_lat_lon.py
@@ -1,5 +1,13 @@
 """Contains the `SlepianLimitLatLon` class."""
 
+__lazy_modules__ = [
+    "numba",
+    "numpy",
+    "platformdirs",
+    "pyssht",
+    "typing_extensions",
+]
+
 import pathlib
 
 import numba

--- a/src/sleplet/slepian/slepian_polar_cap.py
+++ b/src/sleplet/slepian/slepian_polar_cap.py
@@ -1,5 +1,13 @@
 """Contains the `SlepianPolarCap` class."""
 
+__lazy_modules__ = [
+    "gmpy2",
+    "numpy",
+    "platformdirs",
+    "pyssht",
+    "typing_extensions",
+]
+
 import concurrent.futures
 import dataclasses
 import logging

--- a/src/sleplet/slepian_methods.py
+++ b/src/sleplet/slepian_methods.py
@@ -1,5 +1,10 @@
 """Methods to work with Slepian coefficients."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pyssht",
+]
+
 import logging
 
 import numpy as np

--- a/src/sleplet/wavelet_methods.py
+++ b/src/sleplet/wavelet_methods.py
@@ -1,5 +1,11 @@
 """Methods to work with wavelet and wavelet coefficients."""
 
+__lazy_modules__ = [
+    "numpy",
+    "pys2let",
+    "pyssht",
+]
+
 import numpy as np
 import numpy.typing as npt
 


### PR DESCRIPTION
[PEP 810](https://peps.python.org/pep-0810/) introduces the concept of `lazy` imports, this feature comes in Python `3.15`. I had thought we would have to wait until `3.15` is the lowest version, but turns out `__lazy_modules__` exists now, and enables backwards compatibility. So it doesn't do anything for now, but once we enable `3.15` it will work automatically.
